### PR TITLE
The curl command builder will now always specify a method

### DIFF
--- a/src/sphinxcontrib/httpexample/builders.py
+++ b/src/sphinxcontrib/httpexample/builders.py
@@ -49,10 +49,6 @@ EXCLUDE_HEADERS_REQUESTS = EXCLUDE_HEADERS + [
 def build_curl_command(request):
     parts = ['curl', '-i']
 
-    # Method
-    if request.command != 'GET':
-        parts.append('-X {}'.format(request.command))
-
     # URL
     parts.append(shlex_quote(request.url()))
 


### PR DESCRIPTION
This way for GET calls with a json body, curl will not default to a `PUT` as seen in https://github.com/rotki/rotki/issues/2612